### PR TITLE
Relax types of underF and overF to allow different input & output functors

### DIFF
--- a/Control/Newtype.hs
+++ b/Control/Newtype.hs
@@ -148,13 +148,13 @@ over :: (Newtype n,  Newtype n', o' ~ O n', o ~ O n)
 over _ f = pack . f . unpack
 
 -- | 'under' lifted into a Functor.
-underF :: (Newtype n, Newtype n', o' ~ O n', o ~ O n, Functor f)
-       => (o -> n) -> (f n -> f n') -> (f o -> f o')
+underF :: (Newtype n, Newtype n', o' ~ O n', o ~ O n, Functor f, Functor g)
+       => (o -> n) -> (f n -> g n') -> (f o -> g o')
 underF _ f = fmap unpack . f . fmap pack
 
 -- | 'over' lifted into a Functor.
-overF :: (Newtype n, Newtype n', o' ~ O n', o ~ O n, Functor f)
-      => (o -> n) -> (f o -> f o') -> (f n -> f n')
+overF :: (Newtype n, Newtype n', o' ~ O n', o ~ O n, Functor f, Functor g)
+      => (o -> n) -> (f o -> g o') -> (f n -> g n')
 overF _ f = fmap pack . f . fmap unpack
 
 instance Newtype All where

--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -1,5 +1,5 @@
 Name:                newtype-generics
-Version:             0.4.1
+Version:             0.4.2
 Synopsis:            A typeclass and set of functions for working with newtypes, with generics support.
 Description:         Per Conor McBride, the Newtype typeclass represents the packing and unpacking of a newtype,
                      and allows you to operatate under that newtype with functions such as ala.
@@ -17,7 +17,7 @@ Cabal-version:       >=1.10
 
 Library
   Exposed-modules:     Control.Newtype
-  Build-depends:       base >= 4.5 && < 4.9
+  Build-depends:       base >= 4.5 && < 5
   -- Other-modules:       
   -- Build-tools:         
   Ghc-options: -Wall


### PR DESCRIPTION
The types of `underF` and `overF` unnecessarily restrict use to share a single functor, which blocked me from using them.

I also changed the `base` upper bound from `< 4.9` to `< 5` for use with GHC 8.1.20160405.