### PR TITLE
Upgrade dependencies

### DIFF
--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -31,7 +31,7 @@ test-suite test
   type:               exitcode-stdio-1.0
   main-is:            main.hs
   hs-source-dirs:     test,.
-  build-depends:      base              >= 4.5 && < 4.9
+  build-depends:      base
                     , hspec             >= 2.1 && < 2.3
                     , HUnit             >= 1.2.5.2 && < 1.4
   default-language:   Haskell2010

--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -17,7 +17,7 @@ Cabal-version:       >=1.10
 
 Library
   Exposed-modules:     Control.Newtype
-  Build-depends:       base >= 4.5 && < 4.9
+  Build-depends:       base >= 4.5 && < 4.10
   -- Other-modules:       
   -- Build-tools:         
   Ghc-options: -Wall

--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -33,5 +33,5 @@ test-suite test
   hs-source-dirs:     test,.
   build-depends:      base              >= 4.5 && < 4.9
                     , hspec             >= 2.1 && < 2.3
-                    , HUnit             >= 1.2.5.2 && < 1.3
+                    , HUnit             >= 1.2.5.2 && < 1.4
   default-language:   Haskell2010


### PR DESCRIPTION
This pull request upgrades the dependencies to allow base 4.9 (GHC 8.0.1) and HUnit 1.3. With these changes, this project can be built with all Stackage snapshots from LTS 3 to the current nightly. It can also be built with the GHC 8.0.1 release candidate. 

If desired, I can split this into two pull requests: One for HUnit and another for base. 