### PR TITLE
GHC.Generics are in base starting from 4.6

### DIFF
--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -17,7 +17,7 @@ Cabal-version:       >=1.10
 
 Library
   Exposed-modules:     Control.Newtype
-  Build-depends:       base >= 4.5 && < 4.10
+  Build-depends:       base >= 4.6 && < 4.10
   -- Other-modules:       
   -- Build-tools:         
   Ghc-options: -Wall


### PR DESCRIPTION
For GHC 7.6 you'd need to depend on ghc-prim

I corrected bounds on Hackage