### PR TITLE
Remove version bounds for testsuite to create compatibility with hspec-2.4, add stack.yaml

### DIFF
--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -32,6 +32,6 @@ test-suite test
   main-is:            main.hs
   hs-source-dirs:     test,.
   build-depends:      base
-                    , hspec             >= 2.1 && < 2.4
-                    , HUnit             >= 1.2.5.2 && < 1.6
+                    , hspec             >= 2.1
+                    , HUnit             >= 1.2.5.2
   default-language:   Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+resolver: lts-7.16
+packages:
+- '.'
+extra-deps:
+- hspec-2.4.0
+- hspec-core-2.4.0
+- hspec-discover-2.4.0
+- hspec-expectations-0.8.2


### PR DESCRIPTION
IMO, version bounds in the testsuite are less important as they don't impact dependency resolution for packages that depend on newtype-generics.

@jcristovao: BTW I'd be interested in becoming a co-maintainer of this package. I could take care of fixing compatibility issues such as this one and triage the occasional issue or PR.