### PR TITLE
Relax base and hspec bounds

### DIFF
--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -9,17 +9,17 @@ License:             BSD3
 License-file:        LICENSE
 Author:              Darius Jahandarie, Conor McBride, João Cristóvão
 Maintainer:          João Cristóvão <jmacristovao@gmail.com>
--- Copyright:           
+-- Copyright:
 Category:            Control
 Build-type:          Simple
--- Extra-source-files:  
+-- Extra-source-files:
 Cabal-version:       >=1.10
 
 Library
   Exposed-modules:     Control.Newtype
-  Build-depends:       base >= 4.6 && < 4.10
-  -- Other-modules:       
-  -- Build-tools:         
+  Build-depends:       base >= 4.6 && < 4.11
+  -- Other-modules:
+  -- Build-tools:
   Ghc-options: -Wall
   default-language:   Haskell2010
 
@@ -32,6 +32,6 @@ test-suite test
   main-is:            main.hs
   hs-source-dirs:     test,.
   build-depends:      base
-                    , hspec             >= 2.1 && < 2.4
+                    , hspec             >= 2.1 && < 2.5
                     , HUnit             >= 1.2.5.2 && < 1.6
   default-language:   Haskell2010


### PR DESCRIPTION
base is needed for GHC 8.2 support and
hspec to allow the current stackage hspec-2.4.3

FWIW the tests still pass with GHC 8.2