### PR TITLE
Increment base upper bound to <4.11 for GHC 8.2.1.

### DIFF
--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -17,7 +17,7 @@ Cabal-version:       >=1.10
 
 Library
   Exposed-modules:     Control.Newtype
-  Build-depends:       base >= 4.6 && < 4.10
+  Build-depends:       base >= 4.6 && < 4.11
   -- Other-modules:       
   -- Build-tools:         
   Ghc-options: -Wall


### PR DESCRIPTION
Fixed to compile under GHC 8.2.1, which has base version == 4.10.0.0.